### PR TITLE
Add Boaz to obs group

### DIFF
--- a/team-members/nerc-obs-admins.csv
+++ b/team-members/nerc-obs-admins.csv
@@ -10,3 +10,4 @@ jbasu01,member
 bnshr,member
 EldritchJS,member
 ajamias,member
+bbenshab,member


### PR DESCRIPTION
Boaz, on the Red Hat perf team, is currently using the Albany cluster and wanted some insight into what was going on at the switch level.